### PR TITLE
Update upload-artifact action to latest version

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -104,7 +104,7 @@ jobs:
           cdk deploy --outputs-file cdk-outputs.json --require-approval never || echo "Stack already deployed"
 
       - name: Upload CDK Outputs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cdk-outputs
           path: part4_infrastructure/cdk/cdk-outputs.json
@@ -139,7 +139,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: Download CDK Outputs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: cdk-outputs
           path: ./artifacts
@@ -212,7 +212,7 @@ jobs:
           aws sqs list-queues --query 'QueueUrls[?contains(@, `rearc`) || contains(@, `RearcDataQuest`)]' --output table >> deployment-report.md
 
       - name: Upload Deployment Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: deployment-report
           path: deployment-report.md


### PR DESCRIPTION
Update GitHub Actions artifact actions to v4 to resolve deprecation errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-a5467e4e-cb70-4575-bf1e-d9d069f76981">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a5467e4e-cb70-4575-bf1e-d9d069f76981">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>