### PR TITLE
Fix missing lambda package in ci/cd

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -81,6 +81,36 @@ jobs:
           npm install -g aws-cdk@latest
           cdk --version
 
+      - name: Build Lambda Packages
+        run: |
+          cd part4_infrastructure/lambda_functions
+          
+          # Ensure we have the necessary files
+          if [ ! -f "build_minimal_package.sh" ]; then
+            echo "ERROR: build_minimal_package.sh not found!"
+            exit 1
+          fi
+          
+          # Make build scripts executable
+          chmod +x build_minimal_package.sh
+          chmod +x build_lambda_package.sh
+          chmod +x build_analytics_package.sh
+          
+          # Build the minimal package required by CDK
+          echo "Building minimal Lambda package..."
+          ./build_minimal_package.sh
+          
+          # Verify the package was created
+          if [ ! -f "build-minimal/lambda-minimal-package.zip" ]; then
+            echo "ERROR: lambda-minimal-package.zip was not created!"
+            ls -la build-minimal/ || echo "build-minimal directory does not exist"
+            exit 1
+          fi
+          
+          echo "✅ Lambda packages built successfully"
+          echo "Package size: $(du -h build-minimal/lambda-minimal-package.zip | cut -f1)"
+          ls -la build-minimal/
+
       - name: Bootstrap CDK (if needed)
         run: |
           cd part4_infrastructure/cdk


### PR DESCRIPTION
Add a build step for Lambda packages to the CI/CD workflow to resolve missing asset errors during CDK deployment.

The CI/CD pipeline failed with `ValidationError: Cannot find asset at ...lambda-minimal-package.zip` because the Lambda package was not built before the CDK deployment step.

---
<a href="https://cursor.com/background-agent?bcId=bc-bb6f31d2-80f4-4933-8819-cbc72e2e1d87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bb6f31d2-80f4-4933-8819-cbc72e2e1d87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>