### PR TITLE
Fix deploy aws workflow syntax error

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -320,8 +320,8 @@ jobs:
               workflow_id: 'e2e-pipeline.yml',
               ref: 'main',
               inputs: {
-                environment: '${{ github.event.inputs.environment || ''dev'' }}',
-                'aws-region': '${{ github.event.inputs.aws-region || ''us-east-2'' }}',
+                environment: '${{ github.event.inputs.environment || "dev" }}',
+                'aws-region': '${{ github.event.inputs.aws-region || "us-east-2" }}',
                 'skip-deployment': 'true',
                 'data-validation-timeout': '15'
               }


### PR DESCRIPTION
Fix GitHub Actions workflow syntax error by replacing incorrect double single quotes with double quotes for default values.

---
<a href="https://cursor.com/background-agent?bcId=bc-1815f432-4be5-46b9-afbd-3f29ccabeab4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1815f432-4be5-46b9-afbd-3f29ccabeab4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>