### PR TITLE
Fix CDK update rollback failed state

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -138,6 +138,59 @@ jobs:
           cd part4_infrastructure/cdk
           cdk diff || echo "No differences found or first deployment"
 
+      - name: Check Stack Status and Handle Rollback Failed
+        run: |
+          cd part4_infrastructure/cdk
+          
+          # Check if stack exists and its status
+          STACK_STATUS=$(aws cloudformation describe-stacks --stack-name RearcDataQuestPipeline --query 'Stacks[0].StackStatus' --output text 2>/dev/null || echo "STACK_NOT_FOUND")
+          
+          echo "Current stack status: $STACK_STATUS"
+          
+          if [ "$STACK_STATUS" = "UPDATE_ROLLBACK_FAILED" ]; then
+            echo "⚠️  Stack is in UPDATE_ROLLBACK_FAILED state. Attempting to recover..."
+            
+            # Try to continue rollback first
+            if aws cloudformation continue-update-rollback --stack-name RearcDataQuestPipeline; then
+              echo "✅ Continue rollback initiated successfully"
+              
+              # Wait for rollback to complete
+              echo "⏳ Waiting for rollback to complete..."
+              aws cloudformation wait stack-update-rollback-complete --stack-name RearcDataQuestPipeline || {
+                echo "⚠️  Rollback did not complete successfully. Checking for stuck resources..."
+                
+                # Get stuck resources and try to skip them
+                STUCK_RESOURCES=$(aws cloudformation describe-stack-resources --stack-name RearcDataQuestPipeline --query 'StackResources[?ResourceStatus==`UPDATE_FAILED` || ResourceStatus==`DELETE_FAILED`].LogicalResourceId' --output text)
+                
+                if [ -n "$STUCK_RESOURCES" ]; then
+                  echo "Found stuck resources: $STUCK_RESOURCES"
+                  echo "Attempting to continue rollback with skipped resources..."
+                  aws cloudformation continue-update-rollback --stack-name RearcDataQuestPipeline --resources-to-skip $STUCK_RESOURCES
+                  aws cloudformation wait stack-update-rollback-complete --stack-name RearcDataQuestPipeline
+                fi
+              }
+            else
+              echo "❌ Failed to continue rollback. Manual intervention may be required."
+              exit 1
+            fi
+          elif [ "$STACK_STATUS" = "ROLLBACK_IN_PROGRESS" ]; then
+            echo "⏳ Stack rollback already in progress. Waiting for completion..."
+            aws cloudformation wait stack-update-rollback-complete --stack-name RearcDataQuestPipeline
+          elif [ "$STACK_STATUS" = "UPDATE_IN_PROGRESS" ]; then
+            echo "⏳ Stack update in progress. Waiting for completion..."
+            aws cloudformation wait stack-update-complete --stack-name RearcDataQuestPipeline || {
+              echo "⚠️  Update failed. Checking final status..."
+              FINAL_STATUS=$(aws cloudformation describe-stacks --stack-name RearcDataQuestPipeline --query 'Stacks[0].StackStatus' --output text)
+              if [ "$FINAL_STATUS" = "UPDATE_ROLLBACK_FAILED" ]; then
+                echo "❌ Stack is now in UPDATE_ROLLBACK_FAILED state. Re-run this workflow to recover."
+                exit 1
+              fi
+            }
+          fi
+          
+          echo "✅ Stack is ready for deployment"
+        timeout-minutes: 15
+
       - name: Deploy CDK Stack
         run: |
           cd part4_infrastructure/cdk

--- a/CLOUDFORMATION_ROLLBACK_FAILED_GUIDE.md
+++ b/CLOUDFORMATION_ROLLBACK_FAILED_GUIDE.md
@@ -1,0 +1,197 @@
+# CloudFormation UPDATE_ROLLBACK_FAILED Recovery Guide
+
+## Problem Description
+
+Your CloudFormation stack `RearcDataQuestPipeline` is in an `UPDATE_ROLLBACK_FAILED` state. This occurs when:
+
+1. A stack update fails
+2. CloudFormation attempts to rollback the changes
+3. The rollback operation also fails, leaving the stack in an inconsistent state
+4. The stack cannot be updated until the rollback issue is resolved
+
+## Error Details
+
+```
+❌ RearcDataQuestPipeline failed: ValidationError: Stack:arn:aws:cloudformation:***:944355516553:stack/RearcDataQuestPipeline/4523cec0-6cf4-11f0-82c0-022df240377b is in UPDATE_ROLLBACK_FAILED state and can not be updated.
+```
+
+## Immediate Solutions
+
+### Option 1: Automatic Recovery (Recommended)
+
+The GitHub Actions workflow has been updated to automatically handle this situation. Simply **re-run the failed GitHub Actions workflow** and it will:
+
+1. Detect the `UPDATE_ROLLBACK_FAILED` state
+2. Attempt to continue the rollback automatically
+3. Handle stuck resources by skipping them if necessary
+4. Proceed with the deployment once the stack is in a stable state
+
+### Option 2: Manual Recovery Using the Recovery Script
+
+Run the provided recovery script:
+
+```bash
+# Make the script executable
+chmod +x fix_stack_rollback_failed.sh
+
+# Run the recovery script
+./fix_stack_rollback_failed.sh
+```
+
+The script provides several recovery options:
+1. **Continue rollback** (recommended first attempt)
+2. **Cancel rollback** and manually fix resources
+3. **Skip failed resources** during rollback
+4. **Delete and recreate** the stack
+5. **Check stack drift**
+
+### Option 3: Manual AWS CLI Commands
+
+If you prefer to handle this manually:
+
+#### Step 1: Continue Rollback
+```bash
+aws cloudformation continue-update-rollback --stack-name RearcDataQuestPipeline --region us-east-2
+```
+
+#### Step 2: If Step 1 Fails, Skip Failed Resources
+```bash
+# Get the list of failed resources
+aws cloudformation describe-stack-resources \
+  --stack-name RearcDataQuestPipeline \
+  --region us-east-2 \
+  --query 'StackResources[?ResourceStatus==`UPDATE_FAILED` || ResourceStatus==`DELETE_FAILED`].LogicalResourceId' \
+  --output text
+
+# Continue rollback while skipping the failed resources
+aws cloudformation continue-update-rollback \
+  --stack-name RearcDataQuestPipeline \
+  --region us-east-2 \
+  --resources-to-skip <resource-id-1> <resource-id-2>
+```
+
+#### Step 3: Monitor Progress
+```bash
+# Check stack status
+aws cloudformation describe-stacks \
+  --stack-name RearcDataQuestPipeline \
+  --region us-east-2 \
+  --query 'Stacks[0].StackStatus'
+
+# Wait for rollback to complete
+aws cloudformation wait stack-update-rollback-complete \
+  --stack-name RearcDataQuestPipeline \
+  --region us-east-2
+```
+
+## Prevention Strategies
+
+### 1. Improved Error Handling
+
+The updated GitHub Actions workflow now includes:
+- Pre-deployment stack status checks
+- Automatic rollback recovery
+- Better error reporting
+- Timeout handling
+
+### 2. Resource Dependencies
+
+Common causes of rollback failures:
+- **Lambda functions** with external dependencies
+- **IAM roles** with policies that can't be deleted
+- **S3 buckets** that aren't empty
+- **Security groups** with active network interfaces
+
+### 3. Deployment Best Practices
+
+```yaml
+# Enhanced deployment step in GitHub Actions
+- name: Deploy with Enhanced Error Handling
+  run: |
+    cd part4_infrastructure/cdk
+    
+    # Check and fix stack state before deployment
+    STACK_STATUS=$(aws cloudformation describe-stacks --stack-name RearcDataQuestPipeline --query 'Stacks[0].StackStatus' --output text 2>/dev/null || echo "STACK_NOT_FOUND")
+    
+    if [ "$STACK_STATUS" = "UPDATE_ROLLBACK_FAILED" ]; then
+      echo "Recovering from rollback failed state..."
+      aws cloudformation continue-update-rollback --stack-name RearcDataQuestPipeline
+      aws cloudformation wait stack-update-rollback-complete --stack-name RearcDataQuestPipeline
+    fi
+    
+    # Deploy with better error handling
+    cdk deploy --require-approval never --verbose --rollback true
+  timeout-minutes: 30
+```
+
+## Troubleshooting Common Scenarios
+
+### Scenario 1: Lambda Function Update Fails
+```bash
+# If Lambda function is stuck, manually delete the function
+aws lambda delete-function --function-name <function-name> --region us-east-2
+
+# Then continue rollback
+aws cloudformation continue-update-rollback --stack-name RearcDataQuestPipeline --region us-east-2
+```
+
+### Scenario 2: S3 Bucket Can't Be Deleted
+```bash
+# Empty the bucket first
+aws s3 rm s3://bucket-name --recursive --region us-east-2
+
+# Then continue rollback
+aws cloudformation continue-update-rollback --stack-name RearcDataQuestPipeline --region us-east-2
+```
+
+### Scenario 3: IAM Role Deletion Fails
+```bash
+# Detach policies manually
+aws iam list-attached-role-policies --role-name <role-name>
+aws iam detach-role-policy --role-name <role-name> --policy-arn <policy-arn>
+
+# Then continue rollback
+aws cloudformation continue-update-rollback --stack-name RearcDataQuestPipeline --region us-east-2
+```
+
+## Monitoring and Verification
+
+### Check Stack Status
+```bash
+aws cloudformation describe-stacks \
+  --stack-name RearcDataQuestPipeline \
+  --region us-east-2 \
+  --query 'Stacks[0].{Status:StackStatus,Reason:StatusReason}' \
+  --output table
+```
+
+### View Stack Events
+```bash
+aws cloudformation describe-stack-events \
+  --stack-name RearcDataQuestPipeline \
+  --region us-east-2 \
+  --query 'StackEvents[0:10].{Time:Timestamp,Status:ResourceStatus,Resource:LogicalResourceId,Reason:ResourceStatusReason}' \
+  --output table
+```
+
+### AWS Console Links
+- **CloudFormation Console**: https://us-east-2.console.aws.amazon.com/cloudformation/home?region=us-east-2#/stacks
+- **Specific Stack**: https://us-east-2.console.aws.amazon.com/cloudformation/home?region=us-east-2#/stacks/stackinfo?stackId=RearcDataQuestPipeline
+
+## Next Steps After Recovery
+
+1. **Wait for Stable State**: Ensure the stack is in `UPDATE_ROLLBACK_COMPLETE` or `CREATE_COMPLETE` state
+2. **Re-run Deployment**: Trigger the GitHub Actions workflow again
+3. **Monitor Deployment**: Watch the deployment process for any new issues
+4. **Verify Resources**: Confirm all expected resources are created correctly
+
+## Emergency Contact
+
+If all recovery options fail:
+1. Create a GitHub issue with the full error details
+2. Include the output of `aws cloudformation describe-stack-events`
+3. Consider deleting the stack entirely and redeploying fresh (last resort)
+
+---
+
+**Remember**: The `UPDATE_ROLLBACK_FAILED` state is recoverable. The automatic recovery in the GitHub Actions workflow should handle most cases, but manual intervention is sometimes required for complex resource dependencies.

--- a/fix_stack_rollback_failed.sh
+++ b/fix_stack_rollback_failed.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+
+# Fix CloudFormation Stack in UPDATE_ROLLBACK_FAILED State
+# This script provides multiple options to resolve the stack issue
+
+set -e
+
+STACK_NAME="RearcDataQuestPipeline"
+REGION="${AWS_DEFAULT_REGION:-us-east-2}"
+
+echo "🔧 CloudFormation Stack Recovery Tool"
+echo "======================================"
+echo "Stack Name: $STACK_NAME"
+echo "Region: $REGION"
+echo ""
+
+# Check if AWS CLI is configured
+if ! aws sts get-caller-identity &> /dev/null; then
+    echo "❌ AWS CLI not configured or credentials not available"
+    exit 1
+fi
+
+# Function to check stack status
+check_stack_status() {
+    aws cloudformation describe-stacks \
+        --stack-name "$STACK_NAME" \
+        --region "$REGION" \
+        --query 'Stacks[0].{Status:StackStatus,Reason:StatusReason}' \
+        --output table 2>/dev/null || echo "Stack not found"
+}
+
+# Function to get failed resources
+get_failed_resources() {
+    echo "🔍 Checking for failed resources..."
+    aws cloudformation describe-stack-events \
+        --stack-name "$STACK_NAME" \
+        --region "$REGION" \
+        --query 'StackEvents[?ResourceStatus==`UPDATE_FAILED` || ResourceStatus==`CREATE_FAILED` || ResourceStatus==`DELETE_FAILED`].{Resource:LogicalResourceId,Status:ResourceStatus,Reason:ResourceStatusReason,Time:Timestamp}' \
+        --output table 2>/dev/null || echo "No events found"
+}
+
+echo "📊 Current Stack Status:"
+check_stack_status
+echo ""
+
+echo "🔍 Failed Resources (if any):"
+get_failed_resources
+echo ""
+
+echo "Available recovery options:"
+echo "1. Continue rollback (recommended first attempt)"
+echo "2. Cancel rollback and manually fix resources"
+echo "3. Skip failed resources during rollback"
+echo "4. Delete and recreate the stack"
+echo "5. Check stack drift"
+echo "6. Exit"
+echo ""
+
+read -p "Choose an option (1-6): " choice
+
+case $choice in
+    1)
+        echo "🔄 Attempting to continue rollback..."
+        aws cloudformation continue-update-rollback \
+            --stack-name "$STACK_NAME" \
+            --region "$REGION" && \
+        echo "✅ Continue rollback initiated. Monitor in AWS Console." || \
+        echo "❌ Continue rollback failed. Try option 2 or 3."
+        ;;
+    
+    2)
+        echo "🛑 Canceling rollback..."
+        aws cloudformation cancel-update-stack \
+            --stack-name "$STACK_NAME" \
+            --region "$REGION" && \
+        echo "✅ Rollback canceled. You can now manually fix resources and retry deployment." || \
+        echo "❌ Cancel rollback failed."
+        ;;
+    
+    3)
+        echo "⚠️  This will skip failed resources during rollback."
+        echo "   Failed resources may remain in your account."
+        read -p "Continue? (y/N): " confirm
+        if [[ $confirm =~ ^[Yy]$ ]]; then
+            # Get list of resources that are stuck
+            echo "🔍 Identifying resources to skip..."
+            RESOURCES_TO_SKIP=$(aws cloudformation describe-stack-resources \
+                --stack-name "$STACK_NAME" \
+                --region "$REGION" \
+                --query 'StackResources[?ResourceStatus==`UPDATE_FAILED` || ResourceStatus==`DELETE_FAILED`].LogicalResourceId' \
+                --output text)
+            
+            if [ -n "$RESOURCES_TO_SKIP" ]; then
+                echo "Resources to skip: $RESOURCES_TO_SKIP"
+                aws cloudformation continue-update-rollback \
+                    --stack-name "$STACK_NAME" \
+                    --region "$REGION" \
+                    --resources-to-skip $RESOURCES_TO_SKIP && \
+                echo "✅ Rollback with skipped resources initiated." || \
+                echo "❌ Failed to continue rollback with skipped resources."
+            else
+                echo "ℹ️  No specific failed resources found. Trying normal continue rollback..."
+                aws cloudformation continue-update-rollback \
+                    --stack-name "$STACK_NAME" \
+                    --region "$REGION"
+            fi
+        fi
+        ;;
+    
+    4)
+        echo "🗑️  This will DELETE the entire stack and all its resources!"
+        echo "   Make sure you have backups of any important data."
+        read -p "Are you absolutely sure? Type 'DELETE' to confirm: " confirm
+        if [[ $confirm == "DELETE" ]]; then
+            echo "🔥 Deleting stack..."
+            aws cloudformation delete-stack \
+                --stack-name "$STACK_NAME" \
+                --region "$REGION" && \
+            echo "✅ Stack deletion initiated. Wait for completion before redeploying." || \
+            echo "❌ Stack deletion failed."
+        else
+            echo "❌ Deletion canceled."
+        fi
+        ;;
+    
+    5)
+        echo "🔍 Checking stack drift..."
+        aws cloudformation detect-stack-drift \
+            --stack-name "$STACK_NAME" \
+            --region "$REGION" 2>/dev/null && \
+        echo "✅ Drift detection initiated. Check AWS Console for results." || \
+        echo "❌ Drift detection failed."
+        ;;
+    
+    6)
+        echo "👋 Exiting without changes."
+        exit 0
+        ;;
+    
+    *)
+        echo "❌ Invalid option selected."
+        exit 1
+        ;;
+esac
+
+echo ""
+echo "📊 Updated Stack Status:"
+check_stack_status
+
+echo ""
+echo "📋 Next Steps:"
+echo "1. Monitor the stack status in AWS Console"
+echo "2. Once stack is in UPDATE_ROLLBACK_COMPLETE or CREATE_COMPLETE state, retry your deployment"
+echo "3. If stack is deleted, wait for deletion to complete before redeploying"
+echo ""
+echo "🔗 AWS Console URL:"
+echo "https://${REGION}.console.aws.amazon.com/cloudformation/home?region=${REGION}#/stacks/stackinfo?stackId=${STACK_NAME}"

--- a/quick_fix_rollback.sh
+++ b/quick_fix_rollback.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Quick fix for UPDATE_ROLLBACK_FAILED state
+# This script attempts the most common recovery method
+
+set -e
+
+STACK_NAME="RearcDataQuestPipeline"
+REGION="${AWS_DEFAULT_REGION:-us-east-2}"
+
+echo "🚀 Quick CloudFormation Rollback Recovery"
+echo "========================================="
+echo "Stack: $STACK_NAME"
+echo "Region: $REGION"
+echo ""
+
+# Check current status
+echo "📊 Checking current stack status..."
+STACK_STATUS=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" --query 'Stacks[0].StackStatus' --output text 2>/dev/null || echo "STACK_NOT_FOUND")
+
+echo "Current status: $STACK_STATUS"
+
+if [ "$STACK_STATUS" = "UPDATE_ROLLBACK_FAILED" ]; then
+    echo ""
+    echo "🔄 Attempting to continue rollback (most common fix)..."
+    
+    if aws cloudformation continue-update-rollback --stack-name "$STACK_NAME" --region "$REGION"; then
+        echo "✅ Continue rollback initiated successfully!"
+        echo ""
+        echo "⏳ Waiting for rollback to complete (this may take several minutes)..."
+        
+        if aws cloudformation wait stack-update-rollback-complete --stack-name "$STACK_NAME" --region "$REGION"; then
+            echo "✅ Rollback completed successfully!"
+            echo ""
+            echo "🎉 Your stack is now ready for redeployment!"
+            echo "   You can now re-run your GitHub Actions workflow."
+        else
+            echo "⚠️  Rollback is taking longer than expected or failed."
+            echo "   Check the AWS Console for more details."
+            echo "   You may need to use the advanced recovery options in fix_stack_rollback_failed.sh"
+        fi
+    else
+        echo "❌ Continue rollback failed."
+        echo "   This may require skipping stuck resources."
+        echo "   Run ./fix_stack_rollback_failed.sh for advanced options."
+        exit 1
+    fi
+elif [ "$STACK_STATUS" = "UPDATE_ROLLBACK_COMPLETE" ] || [ "$STACK_STATUS" = "CREATE_COMPLETE" ]; then
+    echo "✅ Stack is already in a good state!"
+    echo "   You can proceed with your deployment."
+elif [ "$STACK_STATUS" = "STACK_NOT_FOUND" ]; then
+    echo "ℹ️  Stack not found. You can proceed with a fresh deployment."
+else
+    echo "ℹ️  Stack is in $STACK_STATUS state."
+    echo "   This may not require immediate action."
+fi
+
+echo ""
+echo "🔗 View in AWS Console:"
+echo "   https://${REGION}.console.aws.amazon.com/cloudformation/home?region=${REGION}#/stacks/stackinfo?stackId=${STACK_NAME}"


### PR DESCRIPTION
Add automatic CloudFormation stack recovery to GitHub Actions to resolve `UPDATE_ROLLBACK_FAILED` errors.

The `UPDATE_ROLLBACK_FAILED` state prevents further stack updates. This PR enhances the GitHub Actions workflow to detect this state and automatically attempt recovery by continuing the rollback, including skipping stuck resources, allowing subsequent deployments to proceed. It also includes manual recovery scripts and comprehensive documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-fcd8afb3-bd4a-4a19-aa7b-fe86cc957ec2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fcd8afb3-bd4a-4a19-aa7b-fe86cc957ec2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>