### PR TITLE
Cdk bootstrap environment creation failure

### DIFF
--- a/part4_infrastructure/cdk/BOOTSTRAP_TROUBLESHOOTING.md
+++ b/part4_infrastructure/cdk/BOOTSTRAP_TROUBLESHOOTING.md
@@ -1,0 +1,97 @@
+# CDK Bootstrap Permission Troubleshooting Guide
+
+## Issue Summary
+The CDK bootstrap command failed with the error:
+```
+User: arn:aws:iam::944355516553:user/chirsm is not authorized to perform: iam:CreateRole
+```
+
+This indicates insufficient IAM permissions to create the required roles for CDK operation.
+
+## Root Cause
+The AWS user `chirsm` has an explicit deny policy that prevents creating IAM roles, which is required for CDK bootstrap.
+
+## Solutions
+
+### Option 1: Use Different AWS Credentials (Recommended)
+
+1. **Configure AWS credentials with sufficient permissions:**
+   ```bash
+   aws configure
+   ```
+   
+   Or set environment variables:
+   ```bash
+   export AWS_ACCESS_KEY_ID=your_access_key
+   export AWS_SECRET_ACCESS_KEY=your_secret_key
+   export AWS_DEFAULT_REGION=us-east-1
+   ```
+
+2. **Required IAM permissions for bootstrap:**
+   - CloudFormation: Create/manage CDKToolkit stack
+   - IAM: Create CDK roles (cdk-*)
+   - S3: Create CDK assets bucket
+   - ECR: Create CDK container repository
+   - SSM: Manage CDK bootstrap parameters
+
+3. **Clean up failed bootstrap and retry:**
+   ```bash
+   aws cloudformation delete-stack --stack-name CDKToolkit
+   aws cloudformation wait stack-delete-complete --stack-name CDKToolkit
+   cdk bootstrap
+   ```
+
+### Option 2: Request Administrator to Bootstrap
+
+If you cannot get the required permissions:
+1. Ask an AWS administrator to run `cdk bootstrap` using privileged credentials
+2. Once bootstrap is complete, you only need `sts:AssumeRole` permissions for `arn:aws:iam::*:role/cdk-*`
+
+### Option 3: Custom Bootstrap with Limited Permissions
+
+Try using custom execution policies:
+```bash
+cdk bootstrap --cloudformation-execution-policies arn:aws:iam::aws:policy/PowerUserAccess
+```
+
+## After Successful Bootstrap
+
+Once bootstrap succeeds, for regular CDK deployments you only need:
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "sts:AssumeRole"
+            ],
+            "Resource": [
+                "arn:aws:iam::*:role/cdk-*"
+            ]
+        }
+    ]
+}
+```
+
+## Verification Steps
+
+After successful bootstrap, verify:
+```bash
+aws sts get-caller-identity
+aws cloudformation describe-stacks --stack-name CDKToolkit --query 'Stacks[0].StackStatus'
+```
+
+Expected result: `"CREATE_COMPLETE"`
+
+## Additional Notes
+
+- Node.js version 18.20.8 is end-of-life; consider upgrading to Node 20+ or 22+
+- The `AdministratorAccess` policy used by default CDK bootstrap can be restricted using custom execution policies
+- For production environments, consider using least-privilege IAM policies instead of full administrator access
+
+## Next Steps
+
+1. Resolve the credential issue using one of the options above
+2. Successfully run `cdk bootstrap`
+3. Proceed with `cdk deploy` for your application stack


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add `BOOTSTRAP_TROUBLESHOOTING.md` to guide users on resolving CDK bootstrap permission errors.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The CDK bootstrap process failed because the AWS user lacked `iam:CreateRole` permissions due to an explicit deny policy. This document provides detailed steps to configure appropriate AWS credentials, clean up the failed stack, and successfully re-run the bootstrap, addressing a common initial setup hurdle.

---
<a href="https://cursor.com/background-agent?bcId=bc-0d221da2-9093-48e6-bb56-c1eba1ca180c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0d221da2-9093-48e6-bb56-c1eba1ca180c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>