### PR TITLE
Find and fix missing data processor lambda

### DIFF
--- a/.github/workflows/e2e-pipeline.yml
+++ b/.github/workflows/e2e-pipeline.yml
@@ -107,14 +107,14 @@ jobs:
         run: |
           cd part4_infrastructure/cdk
           if [ -f cdk-outputs.json ]; then
-            echo "stack-name=RearcDataQuestStack" >> $GITHUB_OUTPUT
+            echo "stack-name=RearcDataQuestPipeline" >> $GITHUB_OUTPUT
             echo "bucket-bls=rearc-quest-bls-data" >> $GITHUB_OUTPUT
             echo "bucket-population=rearc-quest-population-data" >> $GITHUB_OUTPUT
             
             # Get Lambda function names dynamically
-            DATA_PROCESSOR=$(aws lambda list-functions --query 'Functions[?contains(FunctionName, `RearcDataQuest`) && contains(FunctionName, `DataProcessor`)].FunctionName' --output text | head -n1)
-            ANALYTICS_PROCESSOR=$(aws lambda list-functions --query 'Functions[?contains(FunctionName, `RearcDataQuest`) && contains(FunctionName, `Analytics`)].FunctionName' --output text | head -n1)
-            SQS_QUEUE=$(aws sqs list-queues --query 'QueueUrls[?contains(@, `RearcDataQuest`)]' --output text | head -n1)
+            DATA_PROCESSOR=$(aws lambda list-functions --query 'Functions[?contains(FunctionName, `rearc-quest-data-processor`)].FunctionName' --output text | head -n1)
+            ANALYTICS_PROCESSOR=$(aws lambda list-functions --query 'Functions[?contains(FunctionName, `rearc-quest-analytics-processor`)].FunctionName' --output text | head -n1)
+            SQS_QUEUE=$(aws sqs list-queues --query 'QueueUrls[?contains(@, `rearc-quest`)]' --output text | head -n1)
             
             echo "lambda-processor=${DATA_PROCESSOR}" >> $GITHUB_OUTPUT
             echo "lambda-analytics=${ANALYTICS_PROCESSOR}" >> $GITHUB_OUTPUT
@@ -158,14 +158,14 @@ jobs:
           echo "🔍 Discovering existing infrastructure..."
           
           # Set static values for known infrastructure
-          echo "stack-name=RearcDataQuestStack" >> $GITHUB_OUTPUT
+          echo "stack-name=RearcDataQuestPipeline" >> $GITHUB_OUTPUT
           echo "bucket-bls=rearc-quest-bls-data" >> $GITHUB_OUTPUT
           echo "bucket-population=rearc-quest-population-data" >> $GITHUB_OUTPUT
           
           # Get Lambda function names dynamically
-          DATA_PROCESSOR=$(aws lambda list-functions --query 'Functions[?contains(FunctionName, `RearcDataQuest`) && contains(FunctionName, `DataProcessor`)].FunctionName' --output text | head -n1)
-          ANALYTICS_PROCESSOR=$(aws lambda list-functions --query 'Functions[?contains(FunctionName, `RearcDataQuest`) && contains(FunctionName, `Analytics`)].FunctionName' --output text | head -n1)
-          SQS_QUEUE=$(aws sqs list-queues --query 'QueueUrls[?contains(@, `RearcDataQuest`)]' --output text | head -n1)
+          DATA_PROCESSOR=$(aws lambda list-functions --query 'Functions[?contains(FunctionName, `rearc-quest-data-processor`)].FunctionName' --output text | head -n1)
+          ANALYTICS_PROCESSOR=$(aws lambda list-functions --query 'Functions[?contains(FunctionName, `rearc-quest-analytics-processor`)].FunctionName' --output text | head -n1)
+          SQS_QUEUE=$(aws sqs list-queues --query 'QueueUrls[?contains(@, `rearc-quest`)]' --output text | head -n1)
           
           echo "lambda-processor=${DATA_PROCESSOR}" >> $GITHUB_OUTPUT
           echo "lambda-analytics=${ANALYTICS_PROCESSOR}" >> $GITHUB_OUTPUT
@@ -224,13 +224,13 @@ jobs:
           
           # Fallback to dynamic discovery if outputs are empty
           if [ -z "$DATA_PROCESSOR" ]; then
-            DATA_PROCESSOR=$(aws lambda list-functions --query 'Functions[?contains(FunctionName, `RearcDataQuest`) && contains(FunctionName, `DataProcessor`)].FunctionName' --output text | head -n1)
+            DATA_PROCESSOR=$(aws lambda list-functions --query 'Functions[?contains(FunctionName, `rearc-quest-data-processor`)].FunctionName' --output text | head -n1)
           fi
           if [ -z "$ANALYTICS_PROCESSOR" ]; then
-            ANALYTICS_PROCESSOR=$(aws lambda list-functions --query 'Functions[?contains(FunctionName, `RearcDataQuest`) && contains(FunctionName, `Analytics`)].FunctionName' --output text | head -n1)
+            ANALYTICS_PROCESSOR=$(aws lambda list-functions --query 'Functions[?contains(FunctionName, `rearc-quest-analytics-processor`)].FunctionName' --output text | head -n1)
           fi
           if [ -z "$SQS_QUEUE_URL" ]; then
-            SQS_QUEUE_URL=$(aws sqs list-queues --query 'QueueUrls[?contains(@, `RearcDataQuest`)]' --output text | head -n1)
+            SQS_QUEUE_URL=$(aws sqs list-queues --query 'QueueUrls[?contains(@, `rearc-quest`)]' --output text | head -n1)
           fi
           
           echo "data-processor=${DATA_PROCESSOR}" >> $GITHUB_OUTPUT
@@ -320,8 +320,8 @@ jobs:
           echo "Monitoring logs since: ${START_TIME}"
           
           # Get Lambda function names
-          DATA_PROCESSOR=$(aws lambda list-functions --query 'Functions[?contains(FunctionName, `RearcDataQuest`) && contains(FunctionName, `DataProcessor`)].FunctionName' --output text | head -n1)
-          ANALYTICS_PROCESSOR=$(aws lambda list-functions --query 'Functions[?contains(FunctionName, `RearcDataQuest`) && contains(FunctionName, `Analytics`)].FunctionName' --output text | head -n1)
+          DATA_PROCESSOR=$(aws lambda list-functions --query 'Functions[?contains(FunctionName, `rearc-quest-data-processor`)].FunctionName' --output text | head -n1)
+          ANALYTICS_PROCESSOR=$(aws lambda list-functions --query 'Functions[?contains(FunctionName, `rearc-quest-analytics-processor`)].FunctionName' --output text | head -n1)
           
           # Monitor Data Processor logs
           if [ -n "$DATA_PROCESSOR" ]; then
@@ -346,7 +346,7 @@ jobs:
       - name: Check SQS Queue Status
         run: |
           # Get SQS queue URL
-          SQS_QUEUE_URL=$(aws sqs list-queues --query 'QueueUrls[?contains(@, `RearcDataQuest`)]' --output text | head -n1)
+          SQS_QUEUE_URL=$(aws sqs list-queues --query 'QueueUrls[?contains(@, `rearc-quest`)]' --output text | head -n1)
           
           if [ -n "$SQS_QUEUE_URL" ]; then
             echo "📬 SQS Queue Status:"
@@ -457,7 +457,7 @@ jobs:
           START_TIME="${{ needs.trigger-data-pipeline.outputs.pipeline-start-time }}"
           
           # Get Analytics Lambda function name
-          ANALYTICS_PROCESSOR=$(aws lambda list-functions --query 'Functions[?contains(FunctionName, `RearcDataQuest`) && contains(FunctionName, `Analytics`)].FunctionName' --output text | head -n1)
+          ANALYTICS_PROCESSOR=$(aws lambda list-functions --query 'Functions[?contains(FunctionName, `rearc-quest-analytics-processor`)].FunctionName' --output text | head -n1)
           
           if [ -n "$ANALYTICS_PROCESSOR" ]; then
             echo "Checking analytics processing logs..."
@@ -507,11 +507,11 @@ jobs:
           echo "" >> e2e-report.md
           
           echo "### Lambda Functions" >> e2e-report.md
-          aws lambda list-functions --query 'Functions[?contains(FunctionName, `RearcDataQuest`)].{Name:FunctionName,Runtime:Runtime,LastModified:LastModified}' --output table >> e2e-report.md
+          aws lambda list-functions --query 'Functions[?contains(FunctionName, `rearc-quest`)].{Name:FunctionName,Runtime:Runtime,LastModified:LastModified}' --output table >> e2e-report.md
           echo "" >> e2e-report.md
           
           echo "### SQS Queues" >> e2e-report.md
-          aws sqs list-queues --query 'QueueUrls[?contains(@, `RearcDataQuest`)]' --output table >> e2e-report.md
+          aws sqs list-queues --query 'QueueUrls[?contains(@, `rearc-quest`)]' --output table >> e2e-report.md
           echo "" >> e2e-report.md
           
           echo "## Data Validation Results" >> e2e-report.md


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix "Data processor Lambda function not found" error by correcting AWS resource naming patterns in the e2e-pipeline workflow.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The workflow was using incorrect patterns (e.g., `RearcDataQuest` and `RearcDataQuestStack`) to find Lambda functions, SQS queues, and the CDK stack. These have been updated to match the actual deployed resource names (e.g., `rearc-quest-data-processor`, `rearc-quest`, and `RearcDataQuestPipeline`).

---
<a href="https://cursor.com/background-agent?bcId=bc-7a636d0a-4129-4aaa-ba9a-6fe83c32c0f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7a636d0a-4129-4aaa-ba9a-6fe83c32c0f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>