### PR TITLE
Remove AWS CLI installation

### DIFF
--- a/.github/workflows/cdk-deploy-fixed.yml
+++ b/.github/workflows/cdk-deploy-fixed.yml
@@ -24,12 +24,6 @@ jobs:
       with:
         python-version: '3.9'
         
-    - name: Install AWS CLI
-      run: |
-        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-        unzip awscliv2.zip
-        sudo ./aws/install
-        
     - name: Install CDK
       run: npm install -g aws-cdk@latest
       


### PR DESCRIPTION
Remove redundant AWS CLI installation step to speed up workflow.

---
<a href="https://cursor.com/background-agent?bcId=bc-2ea626ff-f6bd-4aea-b648-aa5a495c9066">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2ea626ff-f6bd-4aea-b648-aa5a495c9066">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>