### PR TITLE
Rename stacks and variables for artifact cleanup

### DIFF
--- a/.github/workflows/cdk-deploy-fixed.yml
+++ b/.github/workflows/cdk-deploy-fixed.yml
@@ -99,4 +99,4 @@ jobs:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       run: |
         echo "Verifying stack deployment..."
-        aws cloudformation describe-stacks --stack-name RearcDataQuestPipeline --region $AWS_DEFAULT_REGION --query 'Stacks[0].StackStatus' --output text
+        aws cloudformation describe-stacks --stack-name DataQuestPipelineV2 --region $AWS_DEFAULT_REGION --query 'Stacks[0].StackStatus' --output text

--- a/aws/iam-policy-part1-s3.json
+++ b/aws/iam-policy-part1-s3.json
@@ -15,8 +15,8 @@
                 "s3:PutBucketVersioning"
             ],
             "Resource": [
-                "arn:aws:s3:::rearc-quest-bls-data",
-                "arn:aws:s3:::rearc-quest-bls-data/*"
+                "arn:aws:s3:::data-quest-v2-bls-data",
+                "arn:aws:s3:::data-quest-v2-bls-data/*"
             ]
         },
         {

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -68,7 +68,7 @@ if [ -f "cdk.json" ]; then
     print_status "Found CDK project"
     
     # Check if stack exists
-    if aws cloudformation describe-stacks --stack-name RearcDataQuestPipeline &> /dev/null; then
+    if aws cloudformation describe-stacks --stack-name DataQuestPipelineV2 &> /dev/null; then
         print_status "Stack exists, proceeding with destruction..."
         
         if cdk destroy --force; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -165,8 +165,8 @@ echo
 echo -e "${BLUE}Running Integration Tests...${NC}"
 
 print_status "Testing S3 buckets..."
-aws s3 ls s3://rearc-quest-bls-data/ > /dev/null 2>&1 || print_warning "BLS bucket not found or empty"
-aws s3 ls s3://rearc-quest-population-data/ > /dev/null 2>&1 || print_warning "Population bucket not found or empty"
+aws s3 ls s3://data-quest-v2-bls-data/ > /dev/null 2>&1 || print_warning "BLS bucket not found or empty"
+aws s3 ls s3://data-quest-v2-population-data/ > /dev/null 2>&1 || print_warning "Population bucket not found or empty"
 
 print_status "Testing Lambda functions..."
 LAMBDA_FUNCTIONS=$(aws lambda list-functions --query 'Functions[?contains(FunctionName, `rearc`) || contains(FunctionName, `RearcDataQuest`)].FunctionName' --output text)
@@ -198,22 +198,22 @@ cat > deployment-report.md << EOF
 
 ## S3 Buckets
 \`\`\`
-$(aws s3 ls | grep rearc || echo "No rearc buckets found")
+$(aws s3 ls | grep data-quest-v2 || echo "No data-quest-v2 buckets found")
 \`\`\`
 
 ## Lambda Functions
 \`\`\`
-$(aws lambda list-functions --query 'Functions[?contains(FunctionName, `rearc`) || contains(FunctionName, `RearcDataQuest`)].{Name:FunctionName,Runtime:Runtime,Modified:LastModified}' --output table)
+$(aws lambda list-functions --query 'Functions[?contains(FunctionName, `data-quest-v2`)].{Name:FunctionName,Runtime:Runtime,Modified:LastModified}' --output table)
 \`\`\`
 
 ## SQS Queues
 \`\`\`
-$(aws sqs list-queues --query 'QueueUrls[?contains(@, `rearc`) || contains(@, `RearcDataQuest`)]' --output table)
+$(aws sqs list-queues --query 'QueueUrls[?contains(@, `data-quest-v2`)]' --output table)
 \`\`\`
 
 ## CDK Stack Status
 \`\`\`
-$(aws cloudformation describe-stacks --stack-name RearcDataQuestPipeline --query 'Stacks[0].{Status:StackStatus,Created:CreationTime}' --output table 2>/dev/null || echo "Stack not found")
+$(aws cloudformation describe-stacks --stack-name DataQuestPipelineV2 --query 'Stacks[0].{Status:StackStatus,Created:CreationTime}' --output table 2>/dev/null || echo "Stack not found")
 \`\`\`
 EOF
 

--- a/fix_lambda_dependencies.sh
+++ b/fix_lambda_dependencies.sh
@@ -51,7 +51,7 @@ fi
 print_status "AWS credentials configured"
 
 # Check if Lambda function exists
-FUNCTION_NAME="rearc-quest-data-processor"
+FUNCTION_NAME="data-quest-v2-data-processor"
 if ! aws lambda get-function --function-name "$FUNCTION_NAME" &> /dev/null; then
     print_error "Lambda function '$FUNCTION_NAME' not found"
     print_warning "Please deploy the CDK stack first or check the function name"

--- a/fix_stack_rollback_failed.sh
+++ b/fix_stack_rollback_failed.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-STACK_NAME="RearcDataQuestPipeline"
+STACK_NAME="DataQuestPipelineV2"
 REGION="${AWS_DEFAULT_REGION:-us-east-2}"
 
 echo "🔧 CloudFormation Stack Recovery Tool"

--- a/part1_data_sourcing/bls_data_sync.py
+++ b/part1_data_sourcing/bls_data_sync.py
@@ -426,7 +426,7 @@ def load_environment_config():
     Load configuration from environment variables (GitHub repo secrets).
     """
     config = {
-        'bucket_name': os.environ.get('BLS_BUCKET_NAME', 'rearc-bls-pr-data'),
+        'bucket_name': os.environ.get('BLS_BUCKET_NAME', 'data-quest-v2-bls-data'),
         'base_url': os.environ.get('BLS_BASE_URL', 'https://download.bls.gov/pub/time.series/'),
         'target_series': os.environ.get('BLS_TARGET_SERIES', 'pr').split(','),
         'max_workers': int(os.environ.get('BLS_MAX_WORKERS', '3')),

--- a/part2_api_integration/population_api.py
+++ b/part2_api_integration/population_api.py
@@ -444,7 +444,7 @@ def main():
     Main function to run the population API integration.
     """
     # Configuration
-    BUCKET_NAME = os.environ.get('POPULATION_BUCKET_NAME', 'rearc-quest-population-data')
+    BUCKET_NAME = os.environ.get('POPULATION_BUCKET_NAME', 'data-quest-v2-population-data')
     
     # Initialize client
     client = PopulationAPIClient(BUCKET_NAME)

--- a/part2_api_integration/population_api_fixed.py
+++ b/part2_api_integration/population_api_fixed.py
@@ -403,7 +403,7 @@ def main():
         return
     
     # Configuration
-    BUCKET_NAME = os.environ.get('POPULATION_BUCKET_NAME', 'rearc-quest-population-data')
+    BUCKET_NAME = os.environ.get('POPULATION_BUCKET_NAME', 'data-quest-v2-population-data')
     
     # Initialize client
     client = PopulationAPIClient(BUCKET_NAME)

--- a/part3_analytics/create_notebook.py
+++ b/part3_analytics/create_notebook.py
@@ -61,8 +61,8 @@ notebook = {
             "outputs": [],
             "source": [
                 "# Configuration\n",
-                "BLS_BUCKET_NAME = 'rearc-quest-bls-data'\n",
-                "POPULATION_BUCKET_NAME = 'rearc-quest-population-data'\n",
+                        "BLS_BUCKET_NAME = 'data-quest-v2-bls-data'\n",
+        "POPULATION_BUCKET_NAME = 'data-quest-v2-population-data'\n",
                 "\n",
                 "# Initialize S3 client\n",
                 "s3_client = boto3.client('s3')\n",

--- a/part4_infrastructure/cdk/app.py
+++ b/part4_infrastructure/cdk/app.py
@@ -13,7 +13,7 @@ This application deploys the complete Rearc Data Quest pipeline infrastructure:
 
 import os
 import aws_cdk as cdk
-from pipeline_stack import RearcDataPipelineStack
+from pipeline_stack import DataQuestPipelineStackV2
 
 app = cdk.App()
 
@@ -24,15 +24,15 @@ env = cdk.Environment(
 )
 
 # Deploy the main pipeline stack
-pipeline_stack = RearcDataPipelineStack(
+pipeline_stack = DataQuestPipelineStackV2(
     app, 
-    "RearcDataQuestPipeline",
+    "DataQuestPipelineV2",
     env=env,
-    description="Rearc Data Quest - Complete Data Pipeline Infrastructure"
+    description="Data Quest V2 - Complete Data Pipeline Infrastructure"
 )
 
 # Add tags to all resources
-cdk.Tags.of(app).add("Project", "Rearc-Data-Quest")
+cdk.Tags.of(app).add("Project", "Data-Quest-V2")
 cdk.Tags.of(app).add("Environment", "Production")
 cdk.Tags.of(app).add("Owner", "Data-Engineering-Team")
 

--- a/part4_infrastructure/cdk/fix_stack.sh
+++ b/part4_infrastructure/cdk/fix_stack.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-STACK_NAME=${1:-"RearcDataQuestPipeline"}
+STACK_NAME=${1:-"DataQuestPipelineV2"}
 AWS_REGION=${AWS_DEFAULT_REGION:-"us-east-1"}
 
 echo "🔧 CloudFormation Stack Recovery"
@@ -73,11 +73,11 @@ delete_lambda_functions() {
     
     # Delete the stuck Lambda functions
     aws lambda delete-function \
-        --function-name "rearc-quest-data-processor" \
+        --function-name "data-quest-v2-data-processor" \
         --region "$AWS_REGION" 2>/dev/null && echo "✅ Deleted data-processor function" || echo "⚠️  Could not delete data-processor (may not exist)"
     
     aws lambda delete-function \
-        --function-name "rearc-quest-analytics-processor" \
+        --function-name "data-quest-v2-analytics-processor" \
         --region "$AWS_REGION" 2>/dev/null && echo "✅ Deleted analytics-processor function" || echo "⚠️  Could not delete analytics-processor (may not exist)"
 }
 

--- a/part4_infrastructure/cdk/fix_stack_rollback.py
+++ b/part4_infrastructure/cdk/fix_stack_rollback.py
@@ -38,7 +38,7 @@ def get_stack_name():
         pass
     
     # Default stack name
-    return "RearcDataQuestPipeline"
+    return "DataQuestPipelineV2"
 
 def check_stack_status(cf_client, stack_name):
     """Check the current status of the stack."""
@@ -128,8 +128,8 @@ def delete_stuck_resources_manually(stack_name):
     print("="*60)
     print("\nThe Lambda functions appear to be stuck. Try these manual steps:")
     print("\n1. Delete Lambda functions manually:")
-    print("   aws lambda delete-function --function-name rearc-quest-data-processor")
-    print("   aws lambda delete-function --function-name rearc-quest-analytics-processor")
+    print("   aws lambda delete-function --function-name data-quest-v2-data-processor")
+    print("   aws lambda delete-function --function-name data-quest-v2-analytics-processor")
     
     print("\n2. Then retry the rollback:")
     print(f"   aws cloudformation continue-update-rollback --stack-name {stack_name}")

--- a/part4_infrastructure/cdk/pipeline_stack.py
+++ b/part4_infrastructure/cdk/pipeline_stack.py
@@ -26,9 +26,9 @@ from aws_cdk import (
 )
 from constructs import Construct
 
-class RearcDataPipelineStack(Stack):
+class DataQuestPipelineStackV2(Stack):
     """
-    Main stack for the Rearc Data Quest pipeline infrastructure.
+    Main stack for the Data Quest pipeline infrastructure - Version 2.
     """
 
     def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
@@ -41,7 +41,7 @@ class RearcDataPipelineStack(Stack):
         # BLS data bucket
         self.bls_bucket = s3.Bucket(
             self, "BLSDataBucket",
-            bucket_name="rearc-quest-bls-data",
+            bucket_name="data-quest-v2-bls-data",
             versioned=True,
             removal_policy=RemovalPolicy.DESTROY,  # For demo purposes
             auto_delete_objects=True,  # For demo purposes
@@ -52,7 +52,7 @@ class RearcDataPipelineStack(Stack):
         # Population data bucket
         self.population_bucket = s3.Bucket(
             self, "PopulationDataBucket",
-            bucket_name="rearc-quest-population-data",
+            bucket_name="data-quest-v2-population-data",
             versioned=True,
             removal_policy=RemovalPolicy.DESTROY,  # For demo purposes
             auto_delete_objects=True,  # For demo purposes
@@ -67,14 +67,14 @@ class RearcDataPipelineStack(Stack):
         # Dead letter queue
         self.dlq = sqs.Queue(
             self, "AnalyticsDLQ",
-            queue_name="rearc-quest-analytics-dlq",
+            queue_name="data-quest-v2-analytics-dlq",
             retention_period=Duration.days(14)
         )
 
         # Main analytics queue
         self.analytics_queue = sqs.Queue(
             self, "AnalyticsQueue",
-            queue_name="rearc-quest-analytics-queue",
+            queue_name="data-quest-v2-analytics-queue",
             visibility_timeout=Duration.minutes(6),  # 6x lambda timeout
             dead_letter_queue=sqs.DeadLetterQueue(
                 max_receive_count=3,
@@ -120,7 +120,7 @@ class RearcDataPipelineStack(Stack):
         # Data processor Lambda (Parts 1 & 2 combined)
         self.data_processor_lambda = lambda_.Function(
             self, "DataProcessorFunction",
-            function_name="rearc-quest-data-processor",
+            function_name="data-quest-v2-data-processor",
             runtime=lambda_.Runtime.PYTHON_3_9,
             handler="data_processor.lambda_handler",
             code=lambda_.Code.from_asset("../lambda_functions/build-minimal/lambda-minimal-package.zip"),
@@ -139,7 +139,7 @@ class RearcDataPipelineStack(Stack):
         # Consider using Lambda Layers or container images for production deployment
         self.analytics_processor_lambda = lambda_.Function(
             self, "AnalyticsProcessorFunction",
-            function_name="rearc-quest-analytics-processor",
+            function_name="data-quest-v2-analytics-processor",
             runtime=lambda_.Runtime.PYTHON_3_9,
             handler="analytics_processor.lambda_handler",
             code=lambda_.Code.from_asset("../lambda_functions"),
@@ -159,7 +159,7 @@ class RearcDataPipelineStack(Stack):
         # Daily schedule for data processor
         self.daily_schedule = events.Rule(
             self, "DailyDataProcessingSchedule",
-            rule_name="rearc-quest-daily-schedule",
+            rule_name="data-quest-v2-daily-schedule",
             description="Daily trigger for BLS and Population data processing",
             schedule=events.Schedule.cron(
                 minute="0",

--- a/quick_fix_rollback.sh
+++ b/quick_fix_rollback.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-STACK_NAME="RearcDataQuestPipeline"
+STACK_NAME="DataQuestPipelineV2"
 REGION="${AWS_DEFAULT_REGION:-us-east-2}"
 
 echo "🚀 Quick CloudFormation Rollback Recovery"


### PR DESCRIPTION
Rename CDK stack, AWS resources, and related variables to avoid conflicts with old deployments.

The renaming ensures a clean state for new deployments, preventing interference from previously deployed artifacts and providing clear versioning for the updated solution.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e1518a4-b9b3-4fb3-b8d5-8eadfc7e0048">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5e1518a4-b9b3-4fb3-b8d5-8eadfc7e0048">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>