### PR TITLE
Fix invalid base64 encoding in data pipeline

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -303,9 +303,11 @@ jobs:
       - name: Test Lambda Functions
         run: |
           echo "Testing Lambda functions..."
+          # Create test payload file
+          echo '{"test": true}' > /tmp/test-payload.json
           for func in $(aws lambda list-functions --query 'Functions[?contains(FunctionName, `rearc`) || contains(FunctionName, `RearcDataQuest`)].FunctionName' --output text); do
             echo "Testing function: $func"
-            aws lambda invoke --function-name "$func" --payload '{"test": true}' /tmp/response.json || echo "Function invocation failed for $func"
+            aws lambda invoke --function-name "$func" --payload file:///tmp/test-payload.json /tmp/response.json || echo "Function invocation failed for $func"
           done
 
       - name: Generate Deployment Report

--- a/.github/workflows/e2e-pipeline.yml
+++ b/.github/workflows/e2e-pipeline.yml
@@ -266,8 +266,8 @@ jobs:
           if [ -n "$DATA_PROCESSOR" ]; then
             echo "Invoking Data Processor Lambda: ${DATA_PROCESSOR}"
             
-            # Create payload with test identifier
-            PAYLOAD=$(cat <<EOF
+            # Create payload file with test identifier
+            cat > /tmp/lambda-payload.json <<EOF
           {
             "source": "github-actions-e2e",
             "executionId": "${EXECUTION_ID}",
@@ -275,17 +275,17 @@ jobs:
             "triggerAnalytics": true
           }
           EOF
-          )
             
-            # Invoke Lambda function asynchronously
+            # Invoke Lambda function asynchronously using file-based payload
             aws lambda invoke \
               --function-name "$DATA_PROCESSOR" \
               --invocation-type Event \
-              --payload "$PAYLOAD" \
+              --payload file:///tmp/lambda-payload.json \
               /tmp/lambda-response.json
               
             echo "✅ Data processor triggered successfully"
-            echo "Payload sent: $PAYLOAD"
+            echo "Payload sent:"
+            cat /tmp/lambda-payload.json
           else
             echo "❌ Data processor Lambda function not found"
             exit 1


### PR DESCRIPTION
Fixes 'Invalid base64' error by passing AWS Lambda invoke payloads via temporary files instead of direct strings.

The AWS CLI expects direct string payloads to be base64-encoded, which was not happening, leading to the "Invalid base64" error. Using `file://` avoids this encoding requirement.

---
<a href="https://cursor.com/background-agent?bcId=bc-97ba9b34-f95e-415f-bd4a-2461f24b8299">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-97ba9b34-f95e-415f-bd4a-2461f24b8299">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>