### PR TITLE
Fix lambda invocation payload encoding

### DIFF
--- a/.github/workflows/e2e-pipeline.yml
+++ b/.github/workflows/e2e-pipeline.yml
@@ -280,6 +280,7 @@ jobs:
             aws lambda invoke \
               --function-name "$DATA_PROCESSOR" \
               --invocation-type Event \
+              --cli-binary-format raw-in-base64-out \
               --payload file:///tmp/lambda-payload.json \
               /tmp/lambda-response.json
               

--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -171,6 +171,7 @@ aws s3 ls s3://rearc-quest-population-data/population-data/
 # Manually invoke data processor
 aws lambda invoke \
   --function-name rearc-quest-data-processor \
+  --cli-binary-format raw-in-base64-out \
   --payload '{}' \
   response.json
 
@@ -180,6 +181,7 @@ cat response.json
 # Manually invoke analytics processor
 aws lambda invoke \
   --function-name rearc-quest-analytics-processor \
+  --cli-binary-format raw-in-base64-out \
   --payload '{
     "Records": [{
       "body": "{\"test\": true}"

--- a/LAMBDA_FIX_GUIDE.md
+++ b/LAMBDA_FIX_GUIDE.md
@@ -121,6 +121,7 @@ After deployment, test the Lambda function:
 ```bash
 aws lambda invoke \
   --function-name rearc-quest-data-processor \
+  --cli-binary-format raw-in-base64-out \
   --payload '{}' \
   response.json
 

--- a/fix_lambda_dependencies.sh
+++ b/fix_lambda_dependencies.sh
@@ -95,6 +95,7 @@ RESPONSE_FILE="/tmp/lambda_response.json"
 
 aws lambda invoke \
     --function-name "$FUNCTION_NAME" \
+    --cli-binary-format raw-in-base64-out \
     --payload '{}' \
     "$RESPONSE_FILE" \
     --output table


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add `--cli-binary-format raw-in-base64-out` to AWS Lambda invocations to fix "Invalid base64" errors.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The AWS CLI's `--payload` argument expects Base64-encoded binary data by default. This flag instructs the CLI to accept raw JSON input and handle the Base64 encoding automatically, resolving the "Invalid base64" error when passing unencoded JSON.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf2324cd-58f5-4cdd-b90e-6f2dfb56e11b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cf2324cd-58f5-4cdd-b90e-6f2dfb56e11b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>